### PR TITLE
[ FEAT ] Added GitHub Action workflow

### DIFF
--- a/src/.github/workflows/main.yml
+++ b/src/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: PR Owner Checker
+on: 
+  pull_request:
+    branches: 
+      - main
+      - devel
+
+jobs:
+  checker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: main
+
+    - uses: jtapia-xepelin/pr_owner_checker@main
+      with:
+        prNum: ${{ github.event.pull_request.number }}
+        targetOrg: "xepelinapp"
+        targetTeam: "data-crowd"
+        targetRepo: "dbt-dw-data-team"
+      env:
+        GH_TOKEN: ${{ secrets.AUTH_TOKEN }}


### PR DESCRIPTION
Este PR agrega un flujo de prueba de GitHub Actions, para mostrar cómo se utilizan (y desarrollan) las GitHub Actions con esta acción. En la pestaña [Actions](https://github.com/xepelinapp/datacrowd-pr_owner_checker/actions) se puede ver el flujo final de esta acción, y su resultado. 